### PR TITLE
Fixed bug for gcc 4.7.

### DIFF
--- a/src/ckilo.h
+++ b/src/ckilo.h
@@ -376,6 +376,6 @@ namespace ares
     }
 
     //! デフォルトコンストラクタ.
-    CKilo() : kilo({{{0}}}) {}
+    CKilo() : kilo{{{0}}} {}
   };
 }

--- a/src/sqlite3_wrapper.h
+++ b/src/sqlite3_wrapper.h
@@ -554,10 +554,12 @@ namespace sqlite3_wrapper
     template <class T>
     void fill_column(T & vec, int icol, int jcol)
     {
+      typedef typename T::value_type::first_type T1;
+      typedef typename T::value_type::second_type T2;
       for(iterator itr=this->execute(); itr; ++itr)
       {
-        vec.push_back(std::make_pair(itr[icol],
-                                     itr[jcol]));
+        vec.push_back(std::make_pair(static_cast<T1>(itr[icol]),
+                                     static_cast<T2>(itr[jcol])));
       }
     }
   };

--- a/test/test_cdatabase.cpp
+++ b/test/test_cdatabase.cpp
@@ -64,7 +64,8 @@ protected:
                                               ares::find_mode mode,     \
                                               const char * query) {     \
     ares::station_vector sidresult;                                     \
-    SCOPED_TRACE("check get station name with "BOOST_PP_STRINGIZE(col));\
+    SCOPED_TRACE("check get station name with "                         \
+                 BOOST_PP_STRINGIZE(col));                              \
     db->BOOST_PP_CAT(find_stationid_with_,col)(query, mode, sidresult); \
     diffStationNameVector(std::move(reference), sidresult);             \
   }


### PR DESCRIPTION
Fixed several problems.
- deleted warning about initializer-list with non class type.
- solve the problem using make_pair with implicit cast of column_value.
- split text literal & BOOST_STRINGIZE macro not to evaluated as user defined literal.
